### PR TITLE
Update mqtt-packet sub-dependency to 6.7.0 which has no longer issues.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vrpc",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -494,8 +494,30 @@
           "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
           "requires": {
             "define-properties": "^1.1.3",
+            "es-abstract": "^1.18.0-next.0",
             "has-symbols": "^1.0.1",
             "object-keys": "^1.1.1"
+          },
+          "dependencies": {
+            "es-abstract": {
+              "version": "1.18.0-next.1",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+              "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+              "requires": {
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.0",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.1",
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
+              }
+            }
           }
         }
       }
@@ -978,9 +1000,9 @@
       }
     },
     "mqtt": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.4.tgz",
-      "integrity": "sha512-g3tJt5UOS1Wqn/xntl4JhlJW51OM8CvgEmY8cwZ1zecE5G7uuwjSUUvgGeVDiEMWJ5vXCfZz2VMCQGNvKhzfEQ==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.2.6.tgz",
+      "integrity": "sha512-GpxVObyOzL0CGPBqo6B04GinN8JLk12NRYAIkYvARd9ZCoJKevvOyCaWK6bdK/kFSDj3LPDnCsJbezzNlsi87Q==",
       "requires": {
         "commist": "^1.0.0",
         "concat-stream": "^2.0.0",
@@ -988,6 +1010,7 @@
         "help-me": "^1.0.1",
         "inherits": "^2.0.3",
         "minimist": "^1.2.5",
+        "mqtt-packet": "^6.6.0",
         "pump": "^3.0.0",
         "readable-stream": "^3.6.0",
         "reinterval": "^1.1.0",
@@ -997,9 +1020,9 @@
       }
     },
     "mqtt-packet": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.5.0.tgz",
-      "integrity": "sha512-Pzv0auCMip3D2JZId5n8q084ASyi3AvpjP1qJUf9d/gjuk2YkjD5xSUe/KPKgXIqfr5x99bRm5FdAm7ag96RBQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.7.0.tgz",
+      "integrity": "sha512-GzgeeCirQpB59FyhHvf8BLiIYgxctPSxuSyaF2vWnkt7paX7jtuQ8Gpl+DkHCxZmYuv7GQE6zcUAegpafd0MqQ==",
       "requires": {
         "bl": "^4.0.2",
         "debug": "^4.1.1",
@@ -1693,9 +1716,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
+      "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "ajv": "^6.10.0",
     "argparse": "^2.0.1",
     "caller": "^1.0.1",
-    "mqtt": "^4.2.4",
-    "mqtt-packet": "6.5.0",
+    "mqtt": "^4.2.6",
     "react-vrpc": "^1.0.0",
     "shortid": "^2.2.14"
   }


### PR DESCRIPTION
This removes its temporary downgrade in 0c76c8a6.

