### PR TITLE
Bugfix/22 trying to wrap a c class that is non copyable will fail to compile unless a operator is defined for the class too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-before_install:
-
 matrix:
   include:
     - language: node_js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Wrong `break` statements when inspecting the client cache for instances to be
   attached to [NodeJS]
+- Compilation error on non-copyable classes [C++-Addon] (#22)
 
 ## [2.3.0] - 13 Jan 2021
 

--- a/test/cpp/vrpcTest.cpp
+++ b/test/cpp/vrpcTest.cpp
@@ -60,35 +60,4 @@ TEST_CASE("Test functionality of generic holder", "[Value]") {
     auto ia = v.get<int>();
     REQUIRE(ia == 1);
   }
-  /* NOTE: Currently unsupported because of windows compiler issues
-  SECTION("Check retrieval without get") {
-    // Store an integer to Value
-    Value v(1);
-    // by value
-    int iv = v;
-    REQUIRE(iv == 1);
-    // by const reference
-    const int& ir = v;
-    REQUIRE(ir == 1);
-    // by std::shared_ptr
-    std::shared_ptr<int> ip = v;
-    REQUIRE(*ip == 1);
-  }
-  */
-  SECTION("Check formatting") {
-    Value v;
-    v = 1;
-    REQUIRE(v.format() == "1");
-    v = "foo";
-    REQUIRE(v.format() == "foo");
-    v = 3.1414;
-    REQUIRE(v.format() == "3.141400");
-    v = std::vector<int>({1, 2, 3, 4});
-    REQUIRE(v.format() == "1,2,3,4");
-    v = std::map<std::string, int>({
-      {"1", 1},
-      {"2", 2}});
-    REQUIRE(v.format() == "{1:1,2:2}");
-    v = std::set<int>({1, 2, 3, 4});
-  }
 }

--- a/vrpc/vrpc.hpp
+++ b/vrpc/vrpc.hpp
@@ -439,47 +439,6 @@ namespace vrpc {
     return signature.empty() ? signature : "-" + signature;
   }
 
-  template <typename T>
-  inline std::string to_string(const T& value) {
-    std::ostringstream s;
-    s << std::fixed << value;
-    return s.str();
-  }
-
-  template <typename T>
-  inline std::string to_string(const std::shared_ptr<T>& value) {
-    std::ostringstream s;
-    s << std::fixed << *value;
-    return s.str();
-  }
-
-  template <typename T>
-  inline std::string to_string(const std::vector<T>& value) {
-    if (value.empty()) return "";
-    std::ostringstream s;
-    typename std::vector<T>::const_iterator it = value.begin();
-    s << to_string(*it);
-    it++;
-    for (; it != value.end(); ++it) {
-      s << "," << to_string(*it);
-    }
-    return s.str();
-  }
-
-  template <typename KeyType, typename ValueType>
-  inline std::string to_string(const std::map<KeyType, ValueType>& value) {
-    if (value.empty()) return "{}";
-    std::ostringstream s;
-    typename std::map<KeyType, ValueType>::const_iterator it = value.begin();
-    s << "{" << to_string(it->first) << ":" << to_string(it->second);
-    it++;
-    for (; it != value.end(); ++it) {
-      s << "," << to_string(it->first) << ":" << to_string(it->second);
-    }
-    s << "}";
-    return s.str();
-  }
-
   namespace detail {
 
     template <typename T>
@@ -590,12 +549,6 @@ namespace vrpc {
       return content ? content->type() : void_type;
     }
 
-    std::string format() const {
-      return content ? content->format() : std::string();
-    }
-
-    friend std::ostream& operator<<(std::ostream& os, const Value& v);
-
     template <typename T>
     inline const T& get() const {
       // TODO Check type correctness here
@@ -631,8 +584,6 @@ namespace vrpc {
       virtual std::type_index type() const noexcept = 0;
 
       virtual placeholder* clone() const = 0;
-
-      virtual std::string format() const = 0;
     };
 
     template<typename T>
@@ -655,10 +606,6 @@ namespace vrpc {
       virtual placeholder* clone() const {
         // This copies a std::shared_ptr!
         return new holder(*held);
-      }
-
-      virtual std::string format() const {
-        return vrpc::to_string(*held);
       }
 
       holder& operator=(const holder&) = delete;
@@ -687,12 +634,7 @@ namespace vrpc {
         return new holder(held);
       }
 
-      virtual std::string format() const {
-        return vrpc::to_string(*held);
-      }
-
       holder& operator=(const holder&) = delete;
-
 
     public: // representation
 
@@ -701,15 +643,6 @@ namespace vrpc {
 
     placeholder* content;
   };
-
-  inline std::ostream& operator<<(std::ostream& os, const Value& value) {
-    try {
-      if (value.content) os << value.content->format();
-    } catch (const std::exception& e) {
-      std::cerr << "Problem formatting value:" << e.what() << std::endl;
-    }
-    return os;
-  }
 
   inline bool operator==(const Value& lhs, const char& rhs) {
     return lhs.get<char>() == rhs;


### PR DESCRIPTION
# Description

closes #22 
