### PR TITLE
fixed missing callback when loading native addon several times

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,7 +3,8 @@
         {
             "name": "Linux",
             "includePath": [
-                "${workspaceFolder}/**"
+                "${workspaceFolder}/**",
+                "~/.nvm/versions/node/v12.20.2/include/node/"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,7 +45,17 @@
     "forward_list": "cpp",
     "unordered_map": "cpp",
     "numeric": "cpp",
-    "cinttypes": "cpp"
+    "cinttypes": "cpp",
+    "atomic": "cpp",
+    "algorithm": "cpp",
+    "iterator": "cpp",
+    "map": "cpp",
+    "memory_resource": "cpp",
+    "optional": "cpp",
+    "regex": "cpp",
+    "set": "cpp",
+    "string": "cpp",
+    "string_view": "cpp"
   },
   "restructuredtext.confPath": "${workspaceFolder}"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - domain inconsistency in the VrpcRemote API [NodeJS] (#33)
 - webpack-5 crash, using custom browser library now (#36)
+- missing callback when same native addon was loaded to different VrpcLocal instances [NodeJS] (#31)
 
 ### Changed
 

--- a/test/examples/examples.spec.sh
+++ b/test/examples/examples.spec.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+cd $(dirname `[[ $0 = /* ]] && echo "$0" || echo "$PWD/${0#./}"`)
+
+# define some colors to use for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# final exit code
+EXIT_CODE=0
+
+# catch unexpected failures, do cleanup and output an error message
+trap 'printf "${RED}Tests Failed For Unexpected Reasons${NC}\n"'\
+  HUP INT QUIT PIPE TERM
+
+# change to examples directory
+cd ../examples
+
+for dir in *; do
+
+  # change into example folder
+  cd $dir
+
+  # install the example
+  ./install.sh
+
+  if [ $? -gt 0 ]; then
+    printf "${RED}Installation of example ${dir} failed${NC}\n"
+    cd ../
+    continue
+  fi
+
+  # test the example
+  ./test.sh
+
+  if [ $? -gt 0 ]; then
+    printf "${RED}Test of example ${dir} failed${NC}\n"
+    EXIT_CODE=1
+  fi
+
+  # change back directory
+  cd ../
+
+done
+
+exit $EXIT_CODE

--- a/test/js/local/cppVrpcLocalTest.js
+++ b/test/js/local/cppVrpcLocalTest.js
@@ -7,110 +7,266 @@ const EventEmitter = require('events')
 const { VrpcLocal } = require('../../../index')
 const addon = require('../../../build/Release/vrpc_test')
 
-const emitter = new EventEmitter()
-const newEntries = []
-const removedEntries = []
 
-// Register callback for new callbacks
-emitter.on('new', entry => newEntries.push(entry))
-emitter.on('removed', entry => removedEntries.push(entry))
 
-describe('An instance of the VrpcLocal class', () => {
-  let vrpc
-  it('should be construct-able given a c++ native addon', () => {
-    vrpc = new VrpcLocal(addon)
-    assert.ok(vrpc)
-  })
-  describe('The corresponding VrpcLocal instance', () => {
-    let testClass
-    let anotherTestClass
-    it('should be able to create a TestClass proxy using default constructor', () => {
-      testClass = vrpc.create('TestClass')
-      assert.ok(testClass)
+describe('Embedding C++ to Node.js', () => {
+  context('An instance of the VrpcLocal class', () => {
+    let vrpc
+    const emitter = new EventEmitter()
+    const newEntries = []
+    const removedEntries = []
+    emitter.on('new', x => newEntries.push(x))
+    emitter.on('removed', x => removedEntries.push(x))
+
+    it('should be construct-able given a c++ native addon', () => {
+      vrpc = new VrpcLocal(addon)
+      assert.ok(vrpc)
     })
-    describe('The corresponding TestClass proxy', () => {
-      it('should have all bound functions as own methods', () => {
-        assert.isFunction(testClass.getRegistry)
-        assert.isFunction(testClass.hasCategory)
-        assert.isFunction(testClass.notifyOnNew)
-        assert.isFunction(testClass.notifyOnRemoved)
-        assert.isFunction(testClass.addEntry)
-        assert.isFunction(testClass.removeEntry)
-        assert.isFunction(testClass.callMeBack)
-        assert.isNotFunction(testClass.crazy)
+    context('The corresponding VrpcLocal instance', () => {
+      let testClass
+      let anotherTestClass
+      it('should be able to create a TestClass proxy using default constructor', () => {
+        testClass = vrpc.create('TestClass')
+        assert.ok(testClass)
       })
-      it('should return an empty object after calling getRegistry()', () => {
-        assert.isEmpty(testClass.getRegistry())
-      })
-      it('should return false after calling getCategory(\'test\')', () => {
-        assert.isFalse(testClass.hasCategory('test'))
-      })
-      it('should allow to register an EventEmitter as callback argument', () => {
-        testClass.notifyOnNew({ emitter, event: 'new' })
-        testClass.notifyOnRemoved({ emitter, event: 'removed' })
-      })
-      it('should add a new entry by calling addEntry(\'test\')', () => {
-        const originalEntry = {
-          member1: 'first entry',
-          member2: 42,
-          member3: 3.14,
-          member4: [0, 1, 2, 3]
-        }
-        testClass.addEntry('test', originalEntry)
-        assert.isTrue(testClass.hasCategory('test'))
-        assert.lengthOf(newEntries, 1)
-        assert.lengthOf(removedEntries, 0)
-        assert.equal(newEntries[0].member1, originalEntry.member1)
-        assert.equal(newEntries[0].member2, originalEntry.member2)
-        assert.closeTo(newEntries[0].member3, originalEntry.member3, 0.00001)
-        assert.deepEqual(newEntries[0].member4, originalEntry.member4)
-        assert.equal(testClass.getRegistry().test[0].member1, originalEntry.member1)
-      })
-      it('should remove the entry by calling removeEntry(\'test\')', () => {
-        const entry = testClass.removeEntry('test')
-        assert.equal(entry.member1, 'first entry')
-        assert.isFalse(testClass.hasCategory('test'))
-        assert.lengthOf(removedEntries, 1)
-      })
-      it('should trigger an exception on further attempts to remove an entry', () => {
-        try {
-          testClass.removeEntry('test')
-          assert.isTrue(false)
-        } catch (err) {
-          assert.equal(err.message, 'Can not remove non-existing category')
-        }
-      })
-      it('should properly receive callbacks', (done) => {
-        testClass.callMeBack(sleepTime => {
-          assert.equal(sleepTime, 100)
-          done()
+      context('The corresponding TestClass proxy', () => {
+        it('should have all bound functions as own methods', () => {
+          assert.isFunction(testClass.getRegistry)
+          assert.isFunction(testClass.hasCategory)
+          assert.isFunction(testClass.notifyOnNew)
+          assert.isFunction(testClass.notifyOnRemoved)
+          assert.isFunction(testClass.addEntry)
+          assert.isFunction(testClass.removeEntry)
+          assert.isFunction(testClass.callMeBack)
+          assert.isNotFunction(testClass.crazy)
+        })
+        it('should return an empty object after calling getRegistry()', () => {
+          assert.isEmpty(testClass.getRegistry())
+        })
+        it('should return false after calling getCategory(\'test\')', () => {
+          assert.isFalse(testClass.hasCategory('test'))
+        })
+        it('should allow to register an EventEmitter as callback argument', () => {
+          testClass.notifyOnNew({ emitter, event: 'new' })
+          testClass.notifyOnRemoved({ emitter, event: 'removed' })
+        })
+        it('should add a new entry by calling addEntry(\'test\')', () => {
+          const originalEntry = {
+            member1: 'first entry',
+            member2: 42,
+            member3: 3.14,
+            member4: [0, 1, 2, 3]
+          }
+          testClass.addEntry('test', originalEntry)
+          assert.isTrue(testClass.hasCategory('test'))
+          assert.lengthOf(newEntries, 1)
+          assert.lengthOf(removedEntries, 0)
+          assert.equal(newEntries[0].member1, originalEntry.member1)
+          assert.equal(newEntries[0].member2, originalEntry.member2)
+          assert.closeTo(newEntries[0].member3, originalEntry.member3, 0.00001)
+          assert.deepEqual(newEntries[0].member4, originalEntry.member4)
+          assert.equal(testClass.getRegistry().test[0].member1, originalEntry.member1)
+        })
+        it('should remove the entry by calling removeEntry(\'test\')', () => {
+          const entry = testClass.removeEntry('test')
+          assert.equal(entry.member1, 'first entry')
+          assert.isFalse(testClass.hasCategory('test'))
+          assert.lengthOf(removedEntries, 1)
+        })
+        it('should trigger an exception on further attempts to remove an entry', () => {
+          try {
+            testClass.removeEntry('test')
+            assert.isTrue(false)
+          } catch (err) {
+            assert.equal(err.message, 'Can not remove non-existing category')
+          }
+        })
+        it('should properly receive callbacks', (done) => {
+          testClass.callMeBack(sleepTime => {
+            assert.equal(sleepTime, 100)
+            done()
+          })
+        })
+        it('should be able to call a static function', () => {
+          assert.equal(vrpc.callStatic('TestClass', 'crazy'), 'who is crazy?')
+        })
+        it('and overloads thereof', () => {
+          assert.equal(vrpc.callStatic('TestClass', 'crazy', 'vrpc'), 'vrpc is crazy!')
+        })
+        it('should create a second instance', async () => {
+          anotherTestClass = vrpc.create(
+            'TestClass',
+            {
+              testEntry: [{
+                member1: 'anotherTestClass',
+                member2: 2,
+                member3: 2.0,
+                member4: [0, 1, 2, 3]
+              }]
+            }
+          )
+          assert.ok(anotherTestClass)
+        })
+        it('should be well separated from the first instance', async () => {
+          const registry = anotherTestClass.getRegistry()
+          assert.equal(registry.testEntry[0].member1, 'anotherTestClass')
+          const registry2 = testClass.getRegistry()
+          assert.deepEqual(registry2, {})
         })
       })
-      it('should be able to call a static function', () => {
-        assert.equal(vrpc.callStatic('TestClass', 'crazy'), 'who is crazy?')
+    })
+  })
+  context('Two instances of the VrpcLocal class', () => {
+    let vrpc1
+    let vrpc2
+    const emitter = new EventEmitter()
+    const newEntries = []
+    const removedEntries = []
+    emitter.on('new', x => newEntries.push(x))
+    emitter.on('removed', x => removedEntries.push(x))
+
+    it('should be construct-able given the same c++ native addon', () => {
+      vrpc1 = new VrpcLocal(addon)
+      vrpc2 = new VrpcLocal(addon)
+      assert.ok(vrpc1)
+      assert.ok(vrpc2)
+
+    })
+    context('The corresponding VrpcLocal instance', () => {
+      let testClass1
+      let testClass2
+      let anotherTestClass1
+      let anotherTestClass2
+      it('should be able to create a TestClass proxy using default constructor', () => {
+        testClass1 = vrpc1.create('TestClass')
+        testClass2 = vrpc2.create('TestClass')
+        assert.ok(testClass1)
+        assert.ok(testClass2)
       })
-      it('and overloads thereof', () => {
-        assert.equal(vrpc.callStatic('TestClass', 'crazy', 'vrpc'), 'vrpc is crazy!')
-      })
-      it('should create a second instance', async () => {
-        anotherTestClass = vrpc.create(
-          'TestClass',
-          {
-            testEntry: [{
-              member1: 'anotherTestClass',
-              member2: 2,
-              member3: 2.0,
-              member4: [0, 1, 2, 3]
-            }]
+      context('The corresponding TestClass proxies', () => {
+        it('should return an empty object after calling getRegistry()', () => {
+          assert.isEmpty(testClass1.getRegistry())
+          assert.isEmpty(testClass2.getRegistry())
+        })
+        it('should return false after calling getCategory(\'test\')', () => {
+          assert.isFalse(testClass1.hasCategory('test'))
+          assert.isFalse(testClass2.hasCategory('test'))
+        })
+        it('should allow to register an EventEmitter as callback argument', () => {
+          testClass1.notifyOnNew({ emitter, event: 'new' })
+          testClass1.notifyOnRemoved({ emitter, event: 'removed' })
+          testClass2.notifyOnNew({ emitter, event: 'new' })
+          testClass2.notifyOnRemoved({ emitter, event: 'removed' })
+        })
+        it('should add a new entry by calling addEntry(\'test\')', () => {
+          const originalEntry = {
+            member1: 'first entry',
+            member2: 42,
+            member3: 3.14,
+            member4: [0, 1, 2, 3]
           }
-        )
-        assert.ok(anotherTestClass)
-      })
-      it('should be well separated from the first instance', async () => {
-        const registry = anotherTestClass.getRegistry()
-        assert.equal(registry.testEntry[0].member1, 'anotherTestClass')
-        const registry2 = testClass.getRegistry()
-        assert.deepEqual(registry2, {})
+          testClass1.addEntry('test', originalEntry)
+          assert.isTrue(testClass1.hasCategory('test'))
+          assert.lengthOf(newEntries, 1)
+          assert.lengthOf(removedEntries, 0)
+          assert.equal(newEntries[0].member1, originalEntry.member1)
+          assert.equal(newEntries[0].member2, originalEntry.member2)
+          assert.closeTo(newEntries[0].member3, originalEntry.member3, 0.00001)
+          assert.deepEqual(newEntries[0].member4, originalEntry.member4)
+          assert.equal(testClass1.getRegistry().test[0].member1, originalEntry.member1)
+          // there should not be any cross-talk by cleanly separated instances
+          assert.isFalse(testClass2.hasCategory('test'))
+          testClass2.addEntry('test', originalEntry)
+          assert.isTrue(testClass2.hasCategory('test'))
+          assert.lengthOf(newEntries, 2)
+          assert.lengthOf(removedEntries, 0)
+          assert.equal(newEntries[1].member1, originalEntry.member1)
+          assert.equal(newEntries[1].member2, originalEntry.member2)
+          assert.closeTo(newEntries[1].member3, originalEntry.member3, 0.00001)
+          assert.deepEqual(newEntries[1].member4, originalEntry.member4)
+          assert.equal(testClass2.getRegistry().test[0].member1, originalEntry.member1)
+        })
+        it('should remove the entry by calling removeEntry(\'test\')', () => {
+          const entry1 = testClass1.removeEntry('test')
+          assert.equal(entry1.member1, 'first entry')
+          assert.isFalse(testClass1.hasCategory('test'))
+          assert.lengthOf(removedEntries, 1)
+          const entry2 = testClass2.removeEntry('test')
+          assert.equal(entry2.member1, 'first entry')
+          assert.isFalse(testClass2.hasCategory('test'))
+          assert.lengthOf(removedEntries, 2)
+        })
+        it('should trigger an exception on further attempts to remove an entry', () => {
+          try {
+            testClass1.removeEntry('test')
+            assert.isTrue(false)
+          } catch (err) {
+            assert.equal(err.message, 'Can not remove non-existing category')
+          }
+          try {
+            testClass2.removeEntry('test')
+            assert.isTrue(false)
+          } catch (err) {
+            assert.equal(err.message, 'Can not remove non-existing category')
+          }
+        })
+        it('should properly receive callbacks (instance1)', (done) => {
+          testClass1.callMeBack(sleepTime => {
+            assert.equal(sleepTime, 100)
+            done()
+          })
+        }),
+        it('should properly receive callbacks (instance2)', (done) => {
+          testClass2.callMeBack(sleepTime => {
+            assert.equal(sleepTime, 100)
+            done()
+          })
+        })
+        it('should be able to call a static function', () => {
+          assert.equal(vrpc1.callStatic('TestClass', 'crazy'), 'who is crazy?')
+          assert.equal(vrpc2.callStatic('TestClass', 'crazy'), 'who is crazy?')
+        })
+        it('and overloads thereof', () => {
+          assert.equal(vrpc1.callStatic('TestClass', 'crazy', 'vrpc'), 'vrpc is crazy!')
+          assert.equal(vrpc2.callStatic('TestClass', 'crazy', 'vrpc'), 'vrpc is crazy!')
+        })
+        it('should create a second instance', async () => {
+          anotherTestClass1 = vrpc1.create(
+            'TestClass',
+            {
+              testEntry: [{
+                member1: 'anotherTestClass1',
+                member2: 2,
+                member3: 2.0,
+                member4: [0, 1, 2, 3]
+              }]
+            }
+          )
+          assert.ok(anotherTestClass1)
+          anotherTestClass2 = vrpc2.create(
+            'TestClass',
+            {
+              testEntry: [{
+                member1: 'anotherTestClass2',
+                member2: 2,
+                member3: 2.0,
+                member4: [0, 1, 2, 3]
+              }]
+            }
+          )
+          assert.ok(anotherTestClass2)
+        })
+        it('should be well separated from the first instance', async () => {
+          const registry1_1 = anotherTestClass1.getRegistry()
+          assert.equal(registry1_1.testEntry[0].member1, 'anotherTestClass1')
+          const registry2_1 = testClass1.getRegistry()
+          assert.deepEqual(registry2_1, {})
+
+          const registry1_2 = anotherTestClass2.getRegistry()
+          assert.equal(registry1_2.testEntry[0].member1, 'anotherTestClass2')
+          const registry2_2 = testClass2.getRegistry()
+          assert.deepEqual(registry2_2, {})
+        })
       })
     })
   })


### PR DESCRIPTION
# Description

This fixes an issue in `addon.cpp`, which should not only memorize a global callback handler but one for every instance.

closes #31 
