### PR TITLE
fixed c++ compiler error on 0 args deprecated macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   using `registerInstance`
 - missing class info messages when successfully reconnecting against a restarted
   broker
+- compiler error when using deprecated C++ binding macros on zero arguments
+  function
 
 ## [2.5.0] - 25 May 2021
 

--- a/vrpc/vrpc.hpp
+++ b/vrpc/vrpc.hpp
@@ -1476,7 +1476,7 @@ namespace vrpc {
           Ret>::registerAs(#Klass, #Function, FunctionDesc, {RetDesc});
 
 #define _VRPC_VOID_MEMBER_FUNCTION_2(Klass, Function) \
-  _VRPC_MEMBER_FUNCTION_3(Klass, Ret, Function)
+  _VRPC_MEMBER_FUNCTION_3(Klass, void, Function)
 
 #define _VRPC_VOID_MEMBER_FUNCTION_CONST_2(Klass, Function) \
   _VRPC_CONST_MEMBER_FUNCTION_3(Klass, void, Function)


### PR DESCRIPTION
# Description

Wrong `Ret` variable instead of correct `void` expression lead to compiler error on deprecate c++ macros with 0 arguments

## How has this been tested?

With the given example in the bug report

closes #43 
